### PR TITLE
delivery finish

### DIFF
--- a/app/controllers/public/deliveries_controller.rb
+++ b/app/controllers/public/deliveries_controller.rb
@@ -17,15 +17,15 @@ class Public::DeliveriesController < ApplicationController
   end
 
   def update
-    @delivery = Delivery.find(params[:id])
-    @delivery.update
-    redirect_to 'index'
+    delivery = Delivery.find(params[:id])
+    delivery.update(delivery_params)
+    redirect_to action: :index
   end
 
   def destroy
     delivery = Delivery.find(params[:id])
     delivery.destroy
-    redirect_to deliveries_path
+    redirect_to action: :index
   end
 
   private

--- a/app/views/public/deliveries/edit.html.erb
+++ b/app/views/public/deliveries/edit.html.erb
@@ -1,11 +1,14 @@
 <h1>配送先編集</h1>
 
-<%= form_with model: @deliver do |f| %>
+<%= form_with model: @delivery, method: :patch  do |f| %>
   <label for="input_post_address">郵便番号（ハイフンなし）</label>
   <%= f.text_field :post_address, autofocus: true, id:"input_post_address", placeholder:"郵便番号を入力してください"%>
+
   <label for="input_address">住所</label>
   <%= f.text_area :address, placeholder:"住所を入力してください" %>
+
   <label for="input_name">名前</label>
-  <%= f.text_field :address, placeholder:"名前を入力してください" %>
+  <%= f.text_field :name, placeholder:"名前を入力してください" %>
+
   <%= f.submit "変更を保存" %>
 <% end %>

--- a/app/views/public/deliveries/index.html.erb
+++ b/app/views/public/deliveries/index.html.erb
@@ -19,7 +19,7 @@
   <p><%= delivery.post_address %></p>
   <p><%= delivery.address %></p>
   <p><%= delivery.name %></p>
-  <%= link_to '編集する', edit_delivery_path(delivery.id) %>
-  <%= link_to '削除する', delivery_path(delivery.id), method: :delete %>
+  <%= link_to '編集する', edit_delivery_path(delivery) %>
+  <%= button_to '削除する', delivery_path(delivery.id), :method=> :delete %>
 </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,7 @@ Rails.application.routes.draw do
       get 'complete', on: :collection
     end
 
-    resources :deliveries, except: [:show, :new]
+    resources :deliveries, only: [:index, :new ,:edit, :create ,:update, :destroy]
 
   end
 


### PR DESCRIPTION
deliveryの作成
※既存のルーティングから一部変更点やlink_toでの問題点があります。
（deliveriesのルーティングを一部変更）
・exceptをonlyに変更（exceptだとeditアクションがPUTになるため）

（配送先削除でHTTPリクエストがGETになってしまう）
・link_toでのmethod: :deleteがなぜか使えないのでbutton_toで設定しています。
現状はbutton_toで機能していますが、正確な原因を突き止めた方が良いかと思います。
